### PR TITLE
Fixed on fetching from xiami

### DIFF
--- a/src/ol_lrc_fetch_xiami.c
+++ b/src/ol_lrc_fetch_xiami.c
@@ -31,8 +31,8 @@
 
 static const char *PREFIX_SEARCH_URL = "http://www.xiami.com/search?key=";
 static const char *PREFIX_LRC_URL = "http://www.xiami.com/song/playlist/id/";
-static const char *TITLE_PATTERN = "href=\"/song/";
-static const char *ARTIST_PATTERN = "href=\"/artist/";
+static const char *TITLE_PATTERN = "href=\"http://www.xiami.com/song/";
+static const char *ARTIST_PATTERN = "href=\"http://www.xiami.com/artist/";
 /* static const char *ALBUM_PATTERN = "href=\"/album/"; */
 /* #define PREFIX_LRC_XIAMI "http://mp3.xiami.com/" */
 /* #define LRC_CLUE_XIAMI "downlrc" */


### PR DESCRIPTION
As metioned in the Issue of OriginRepo:
'It can not fetch lyrics?! #3'
warmsun0220 said:
`the URL of xiami had changed，try to open the file ol_lrc_fetch_xiami.c and change the *TITLE_PATTERN to "href=\"http://www.xiami.com/song/" and recompilation it`
After that, it can fetch the title from xiamia, but the lyric file downloaded contains just an 'HTTP403' page. 
modify `ARTIST_PATTERN` makes it works. 

Modified in the src of `TITLE_PATTERN` and `ARTIST_PATTERN` of xiami in `ol_lrc_fetch_xiami.c`
