### PR TITLE
Add subdir-objects option to Makefile.am

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -13,6 +13,8 @@ check_PROGRAMS = \
         ol_lyric_source_test \
         $(NULL)
 
+AUTOMAKE_OPTIONS = subdir-objects
+
 AM_CPPFLAGS = \
         -DDATADIR='"$(datadir)"' \
         -DICONDIR='"$(OL_ICONDIR)"' \


### PR DESCRIPTION
I added AUTOMAKE_OPTIONS = subdir-objects to src/test/Makefile.am to avoid errors in configuring
